### PR TITLE
Apply zsh-history-substring-search

### DIFF
--- a/.zsh/antigen.zsh
+++ b/.zsh/antigen.zsh
@@ -15,6 +15,8 @@ antigen bundle zsh-users/zsh-syntax-highlighting
 antigen bundle zsh-users/zsh-autosuggestions
 antigen bundle zsh-users/zsh-completions
 
+antigen bundle zsh-users/zsh-history-substring-search
+
 antigen theme romkatv/powerlevel10k
 
 antigen apply

--- a/.zshrc
+++ b/.zshrc
@@ -70,8 +70,13 @@ bindkey "^[[4~" end-of-line
 
 bindkey '^[[Z' reverse-menu-complete
 
-bindkey '^[[A' history-substring-search-up
-bindkey '^[[B' history-substring-search-down
+if [ "$OS" = "macos" ]; then
+    bindkey '^[[A' history-substring-search-up
+    bindkey '^[[B' history-substring-search-down
+elif [ "$OS" = "linux" ]; then
+    bindkey "$key[Up]" history-substring-search-up
+    bindkey "$key[Down]" history-substring-search-down
+fi
 
 #----------------
 # Completion
@@ -84,6 +89,7 @@ setopt auto_menu
 setopt auto_param_keys
 setopt interactive_comments
 setopt magic_equal_subst
+setopt print_eight_bit
 
 setopt complete_in_word
 setopt always_last_prompt

--- a/.zshrc
+++ b/.zshrc
@@ -70,8 +70,8 @@ bindkey "^[[4~" end-of-line
 
 bindkey '^[[Z' reverse-menu-complete
 
-bindkey '^[[A' up-line-or-search
-bindkey '^[[B' down-line-or-search
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
 
 #----------------
 # Completion


### PR DESCRIPTION
## What's done 
Apply Fish shell like history search behavior by install [zsh-users/zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search).

## Screenshot
[![asciicast](https://asciinema.org/a/Rr8FjzU3y0ID19ptiB87U3kD7.svg)](https://asciinema.org/a/Rr8FjzU3y0ID19ptiB87U3kD7)
